### PR TITLE
[Fix & Clean] 修正 `CppCauldronTileEntity` 中 `liquidLevel` 相关的不安全操作，以及 import 清理。

### DIFF
--- a/src/main/java/rc55/mc/cauldronpp/Cauldronpp.java
+++ b/src/main/java/rc55/mc/cauldronpp/Cauldronpp.java
@@ -1,8 +1,5 @@
 package rc55.mc.cauldronpp;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import cpw.mods.fml.client.FMLClientHandler;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.Mod;
@@ -10,6 +7,8 @@ import cpw.mods.fml.common.Mod.EventHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import rc55.mc.cauldronpp.block.CauldronppBlocks;
 import rc55.mc.cauldronpp.client.renderer.CppCauldronTileEntityRenderer;
 import rc55.mc.cauldronpp.item.CauldronppItems;

--- a/src/main/java/rc55/mc/cauldronpp/api/CppCauldronBehavior.java
+++ b/src/main/java/rc55/mc/cauldronpp/api/CppCauldronBehavior.java
@@ -1,7 +1,5 @@
 package rc55.mc.cauldronpp.api;
 
-import java.util.Map;
-
 import net.minecraft.block.Block;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Items;
@@ -10,9 +8,10 @@ import net.minecraft.item.ItemArmor;
 import net.minecraft.item.ItemDye;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
-
 import rc55.mc.cauldronpp.item.CauldronppItems;
 import rc55.mc.cauldronpp.tileEntity.CppCauldronTileEntity;
+
+import java.util.Map;
 
 @FunctionalInterface
 public interface CppCauldronBehavior {

--- a/src/main/java/rc55/mc/cauldronpp/api/CppCauldronLiquidType.java
+++ b/src/main/java/rc55/mc/cauldronpp/api/CppCauldronLiquidType.java
@@ -1,14 +1,13 @@
 package rc55.mc.cauldronpp.api;
 
-import javax.annotation.Nullable;
-
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.util.ResourceLocation;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import rc55.mc.cauldronpp.Cauldronpp;
+
+import javax.annotation.Nullable;
 
 public enum CppCauldronLiquidType {
 

--- a/src/main/java/rc55/mc/cauldronpp/api/CppPotionHelper.java
+++ b/src/main/java/rc55/mc/cauldronpp/api/CppPotionHelper.java
@@ -1,18 +1,18 @@
 package rc55.mc.cauldronpp.api;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
-
 import rc55.mc.cauldronpp.item.CauldronppItems;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@SuppressWarnings("unused")
 public final class CppPotionHelper {
 
     private CppPotionHelper() {}

--- a/src/main/java/rc55/mc/cauldronpp/api/Utils.java
+++ b/src/main/java/rc55/mc/cauldronpp/api/Utils.java
@@ -1,15 +1,15 @@
 package rc55.mc.cauldronpp.api;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.function.Consumer;
-
 import net.minecraft.entity.item.EntityItem;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
 
 public final class Utils {
 

--- a/src/main/java/rc55/mc/cauldronpp/block/CauldronppBlocks.java
+++ b/src/main/java/rc55/mc/cauldronpp/block/CauldronppBlocks.java
@@ -1,8 +1,7 @@
 package rc55.mc.cauldronpp.block;
 
-import net.minecraft.block.Block;
-
 import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
 import rc55.mc.cauldronpp.Cauldronpp;
 
 public class CauldronppBlocks {

--- a/src/main/java/rc55/mc/cauldronpp/block/CppCauldronBlock.java
+++ b/src/main/java/rc55/mc/cauldronpp/block/CppCauldronBlock.java
@@ -1,7 +1,7 @@
 package rc55.mc.cauldronpp.block;
 
-import java.util.Random;
-
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.block.ITileEntityProvider;
@@ -14,14 +14,13 @@ import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.IBlockAccess;
 import net.minecraft.world.World;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import rc55.mc.cauldronpp.Cauldronpp;
 import rc55.mc.cauldronpp.api.CppCauldronBehavior;
 import rc55.mc.cauldronpp.api.CppCauldronLiquidType;
 import rc55.mc.cauldronpp.api.Utils;
 import rc55.mc.cauldronpp.tileEntity.CppCauldronTileEntity;
+
+import java.util.Random;
 
 public class CppCauldronBlock extends BlockCauldron implements ITileEntityProvider {
 

--- a/src/main/java/rc55/mc/cauldronpp/client/renderer/CppCauldronRenderHandler.java
+++ b/src/main/java/rc55/mc/cauldronpp/client/renderer/CppCauldronRenderHandler.java
@@ -1,5 +1,6 @@
 package rc55.mc.cauldronpp.client.renderer;
 
+import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockCauldron;
 import net.minecraft.client.renderer.EntityRenderer;
@@ -8,10 +9,7 @@ import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.init.Blocks;
 import net.minecraft.util.IIcon;
 import net.minecraft.world.IBlockAccess;
-
 import org.lwjgl.opengl.GL11;
-
-import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import rc55.mc.cauldronpp.Cauldronpp;
 import rc55.mc.cauldronpp.block.CauldronppBlocks;
 import rc55.mc.cauldronpp.block.CppCauldronBlock;

--- a/src/main/java/rc55/mc/cauldronpp/client/renderer/CppCauldronTileEntityRenderer.java
+++ b/src/main/java/rc55/mc/cauldronpp/client/renderer/CppCauldronTileEntityRenderer.java
@@ -4,9 +4,7 @@ import net.minecraft.block.Block;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.tileentity.TileEntity;
-
 import org.lwjgl.opengl.GL11;
-
 import rc55.mc.cauldronpp.block.CauldronppBlocks;
 import rc55.mc.cauldronpp.tileEntity.CppCauldronTileEntity;
 

--- a/src/main/java/rc55/mc/cauldronpp/item/CauldronppItems.java
+++ b/src/main/java/rc55/mc/cauldronpp/item/CauldronppItems.java
@@ -1,10 +1,9 @@
 package rc55.mc.cauldronpp.item;
 
+import cpw.mods.fml.common.registry.GameRegistry;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-
-import cpw.mods.fml.common.registry.GameRegistry;
 import rc55.mc.cauldronpp.Cauldronpp;
 import rc55.mc.cauldronpp.block.CauldronppBlocks;
 

--- a/src/main/java/rc55/mc/cauldronpp/item/CppPotionItem.java
+++ b/src/main/java/rc55/mc/cauldronpp/item/CppPotionItem.java
@@ -1,9 +1,8 @@
 package rc55.mc.cauldronpp.item;
 
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.HashMultimap;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.ai.attributes.AttributeModifier;
@@ -19,12 +18,11 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
-
-import com.google.common.collect.HashMultimap;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import rc55.mc.cauldronpp.api.CppPotionHelper;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 public class CppPotionItem extends ItemPotion {
 

--- a/src/main/java/rc55/mc/cauldronpp/item/WaterBottleItem.java
+++ b/src/main/java/rc55/mc/cauldronpp/item/WaterBottleItem.java
@@ -1,7 +1,7 @@
 package rc55.mc.cauldronpp.item;
 
-import java.util.List;
-
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
@@ -9,10 +9,9 @@ import net.minecraft.item.ItemPotion;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.StatCollector;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import rc55.mc.cauldronpp.Cauldronpp;
+
+import java.util.List;
 
 public class WaterBottleItem extends ItemPotion {
 

--- a/src/main/java/rc55/mc/cauldronpp/mixin/early/EarlyMixins.java
+++ b/src/main/java/rc55/mc/cauldronpp/mixin/early/EarlyMixins.java
@@ -1,17 +1,17 @@
 package rc55.mc.cauldronpp.mixin.early;
 
-import java.util.*;
-
 import com.gtnewhorizon.gtnhmixins.IEarlyMixinLoader;
-
 import com.gtnewhorizon.gtnhmixins.builders.IMixins;
 import cpw.mods.fml.common.DummyModContainer;
 import cpw.mods.fml.common.ModMetadata;
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import rc55.mc.cauldronpp.Cauldronpp;
 import rc55.mc.cauldronpp.Tags;
-import rc55.mc.cauldronpp.api.Utils;
 import rc55.mc.cauldronpp.mixin.Mixins;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @IFMLLoadingPlugin.MCVersion("1.7.10")
 public class EarlyMixins extends DummyModContainer implements IEarlyMixinLoader, IFMLLoadingPlugin {

--- a/src/main/java/rc55/mc/cauldronpp/mixin/early/EntityPotionMixin.java
+++ b/src/main/java/rc55/mc/cauldronpp/mixin/early/EntityPotionMixin.java
@@ -1,7 +1,5 @@
 package rc55.mc.cauldronpp.mixin.early;
 
-import java.util.List;
-
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.projectile.EntityPotion;
 import net.minecraft.item.ItemStack;
@@ -9,16 +7,16 @@ import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraft.util.MovingObjectPosition;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
 import rc55.mc.cauldronpp.api.CppPotionHelper;
 import rc55.mc.cauldronpp.api.Utils;
 import rc55.mc.cauldronpp.item.CauldronppItems;
+
+import java.util.List;
 
 @Mixin(EntityPotion.class)
 public abstract class EntityPotionMixin {

--- a/src/main/java/rc55/mc/cauldronpp/mixin/early/ItemAccessor.java
+++ b/src/main/java/rc55/mc/cauldronpp/mixin/early/ItemAccessor.java
@@ -4,7 +4,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Invoker;
 

--- a/src/main/java/rc55/mc/cauldronpp/mixin/early/ItemGlassBottleMixin.java
+++ b/src/main/java/rc55/mc/cauldronpp/mixin/early/ItemGlassBottleMixin.java
@@ -6,12 +6,10 @@ import net.minecraft.item.ItemGlassBottle;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import rc55.mc.cauldronpp.api.Utils;
 import rc55.mc.cauldronpp.item.CauldronppItems;
 

--- a/src/main/java/rc55/mc/cauldronpp/mixin/late/LateMixins.java
+++ b/src/main/java/rc55/mc/cauldronpp/mixin/late/LateMixins.java
@@ -1,11 +1,11 @@
 package rc55.mc.cauldronpp.mixin.late;
 
+import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
+import com.gtnewhorizon.gtnhmixins.LateMixin;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
-import com.gtnewhorizon.gtnhmixins.ILateMixinLoader;
-import com.gtnewhorizon.gtnhmixins.LateMixin;
 
 @LateMixin
 public class LateMixins implements ILateMixinLoader {

--- a/src/main/java/rc55/mc/cauldronpp/tileEntity/CauldronppTileEntity.java
+++ b/src/main/java/rc55/mc/cauldronpp/tileEntity/CauldronppTileEntity.java
@@ -1,10 +1,9 @@
 package rc55.mc.cauldronpp.tileEntity;
 
-import net.minecraft.tileentity.TileEntity;
-
 import cpw.mods.fml.client.registry.ISimpleBlockRenderingHandler;
 import cpw.mods.fml.client.registry.RenderingRegistry;
 import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.tileentity.TileEntity;
 import rc55.mc.cauldronpp.Cauldronpp;
 import rc55.mc.cauldronpp.client.renderer.CppCauldronRenderHandler;
 

--- a/src/main/java/rc55/mc/cauldronpp/tileEntity/CppCauldronTileEntity.java
+++ b/src/main/java/rc55/mc/cauldronpp/tileEntity/CppCauldronTileEntity.java
@@ -1,13 +1,12 @@
 package rc55.mc.cauldronpp.tileEntity;
 
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.network.NetworkManager;
 import net.minecraft.network.Packet;
 import net.minecraft.network.play.server.S35PacketUpdateTileEntity;
 import net.minecraft.tileentity.TileEntity;
-
-import cpw.mods.fml.relauncher.Side;
-import cpw.mods.fml.relauncher.SideOnly;
 import rc55.mc.cauldronpp.api.CppCauldronBehavior;
 import rc55.mc.cauldronpp.api.CppCauldronLiquidType;
 import rc55.mc.cauldronpp.api.CppPotionHelper;
@@ -125,7 +124,7 @@ public class CppCauldronTileEntity extends TileEntity {
     }
 
     public boolean isEmpty() {
-        return this.liquidLevel == 0 || this.liquidType == CppCauldronLiquidType.NONE;
+        return this.liquidLevel <= 0 || this.liquidType == CppCauldronLiquidType.NONE;
     }
 
     public boolean canIncrease(int amount) {
@@ -137,16 +136,23 @@ public class CppCauldronTileEntity extends TileEntity {
     }
 
     public void increase(int amount) {
-        this.liquidLevel += amount;
+        this.liquidLevel = Math.min(this.liquidLevel + amount, CppCauldronBehavior.MAX_AMOUNT);
         this.markDirty();
     }
 
     public void decrease(int amount) {
-        this.liquidLevel -= amount;
+        this.liquidLevel = Math.max(this.liquidLevel - amount, 0);
         if (this.isEmpty()) {
             this.liquidData = 0;
             this.liquidType = CppCauldronLiquidType.NONE;
         }
+        this.markDirty();
+    }
+
+    public void reset() {
+        this.liquidLevel = 0;
+        this.liquidData = 0;
+        this.liquidType = CppCauldronLiquidType.NONE;
         this.markDirty();
     }
 }


### PR DESCRIPTION
如果我们都遵守规范，那么大部分情况下这些不安全的问题不应该发生。但是我们不能总是假定这些不安全的操作不会发生，比如一个意外。这意味着我们需要对代码操作做出一些限制。
就像是方法 `CppCauldronTileEntity#isEmpty` 中使用了代码 `this.liquidLevel == 0`，任何意外的违规操作导致 `liquidLevel` 低于 0 就会导致这个方法失效。

以及新增一个方法 `CppCauldronTileEntity#reset`，为任何又需要的人提供一个快速清空的途径。

`CppCauldronTileEntity` 之外的文件的改动均为 import 清理，未做任何新增或修改。